### PR TITLE
Swap unmaintained assert_approx_eq for a maintained equivalent (feedback welcome)

### DIFF
--- a/pulp/Cargo.toml
+++ b/pulp/Cargo.toml
@@ -44,7 +44,7 @@ macro = ["dep:pulp-macro"]
 
 [dev-dependencies]
 aligned-vec = "0.6.0"
-assert_approx_eq = "1.1.0"
+assertables = "10"
 criterion = "0.5.0"
 diol = { version = "0.8.3", default-features = false }
 rand = "0.8.5"

--- a/pulp/src/x86.rs
+++ b/pulp/src/x86.rs
@@ -353,7 +353,7 @@ mod tests {
 	use super::*;
 	use alloc::vec;
 	use alloc::vec::Vec;
-	use assert_approx_eq::assert_approx_eq;
+	use assertables::assert_approx_eq;
 	use core::iter::zip;
 	use rand::random;
 


### PR DESCRIPTION
Hi Sarah, I'm Joel, maintainer of [assertables](https://github.com/assertables/assertables-rust-crate) which is a Rust crate of assertion macros. 

I'm researching projects that use assert crates, and you use `assert_approx_eq` as a dev-dependency. That crate hasn't had a release in about 8 years (which is of course fine if that's all you want).

The assertables' `assert_approx_eq!` macro has the exact same call shape and the same default epsilon (1e-6), plus optional custom messages. So I'm sending this PR as purely exploratory, to see if you're curious to know more, or if any of the other assert macros could interest you. I'm seeking guidance about how to improve `assertables` because I teach Rust to people and I'm keen on semantic testing.

What this PR suggests:
- `pulp/Cargo.toml`: `assert_approx_eq = "1.1.0"` -> `assertables = "10"` under `[dev-dependencies]`
- `pulp/src/x86.rs`: the single `use assert_approx_eq::assert_approx_eq;` import in the `tests` module, changed to `use assertables::assert_approx_eq;`. All 16 call sites (in `cplx_ops`) use the plain `assert_approx_eq!(a, b)` form, which is unchanged and compiles as-is.

The `assertables` crate is fully hand-written by me personally, no AI. This PR is done by me and AI.

My email is joel@joelparkerhenderson.com if that's helpful for contact and to verify me. 

Thanks for your consideration Sarah, much appreciated.